### PR TITLE
Switched config production to ssl = true

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
On production, API fetch requests were denied from index page due to non-https requests.
In config/environment/production, switched on "config.force_ssl = true" to force all requests to be served over HTTPS.